### PR TITLE
Python 3.8 Support

### DIFF
--- a/pytag/structures.py
+++ b/pytag/structures.py
@@ -1,9 +1,9 @@
-import collections
+from collections.abc import MutableMapping
 
 from pytag.constants import FIELD_NAMES
 
 
-class CaseInsensitiveDict(collections.MutableMapping):
+class CaseInsensitiveDict(MutableMapping):
     """A case-insensitive :py:class:`dict`-like object.
 
     Implements all methods and operations of


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working